### PR TITLE
Conflicting cross version spark tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ spark-warehouse/
 *.Rproj.*
 
 .Rproj.user
+.bloop/
+.metals/
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.roncemer.spark</groupId>
   <artifactId>spark-sql-kinesis_2.13</artifactId>
-  <version>1.2.2_spark-3.2</version>
+  <version>1.2.3_spark-3.2</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>
@@ -58,7 +58,7 @@
     <connection>scm:git:git://github.com/roncemer/spark-sql-kinesis.git</connection>
     <url>http://github.com/roncemer/spark-sql-kinesis</url>
     <developerConnection>scm:git:git@github.com:roncemer/spark-sql-kinesis.git</developerConnection>
-    <tag>spark-sql-kinesis_2.13-1.2.2_spark-3.2</tag>
+    <tag>spark-sql-kinesis_2.13-1.2.3_spark-3.2</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>
@@ -70,7 +70,7 @@
   <properties>
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>3.2.1</spark.version>
-    <scala.binary.version>2.12</scala.binary.version>
+    <scala.binary.version>2.13</scala.binary.version>
     <fasterxml.jackson.version>2.12.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.amazonaws.services.kinesis.model.Record
 import org.apache.hadoop.conf.Configuration
 import scala.collection.parallel.ForkJoinTaskSupport
+import scala.collection.parallel.CollectionConverters._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging

--- a/src/test/scala/org/apache/spark/sql/kinesis/KinesisTestUtils.scala
+++ b/src/test/scala/org/apache/spark/sql/kinesis/KinesisTestUtils.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Random, Success, Try}
@@ -97,7 +97,7 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   }
 
   def getShards(): Seq[Shard] = {
-    kinesisClient.describeStream(_streamName).getStreamDescription.getShards.asScala
+    kinesisClient.describeStream(_streamName).getStreamDescription.getShards.asScala.toSeq
   }
 
   def splitShard(shardId: String): Unit = {
@@ -320,7 +320,7 @@ private[kinesis] class SimpleDataGenerator(
       sentSeqNumbers += ((num, seqNumber))
     }
 
-    shardIdToSeqNumbers.toMap
+    shardIdToSeqNumbers.view.mapValues(_.toList).toMap
   }
 }
 
@@ -369,7 +369,7 @@ private[kinesis] class KPLDataGenerator(regionName: String) extends KinesisDataG
       Futures.addCallback(future, kinesisCallBack, MoreExecutors.directExecutor())
     }
     producer.flushSync()
-    shardIdToSeqNumbers.toMap
+    shardIdToSeqNumbers.mapValues(_.toSeq).toMap
   }
 }
 


### PR DESCRIPTION
The 1.2.2 version was updated for  Scala 2.13 and Spark 3.2.1 but there was a conflict on the Scala build because of "Conflicting cross-version suffixes in: org.apache.spark:spark-tags" 
The error logs is given below:
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(...):
[error]    org.apache.spark:spark-tags _2.13, _2.12
[error] stack trace is suppressed; run 'last update' for the full output
[error] stack trace is suppressed; run 'last ssExtractDependencies' for the full output
[error] (update) Conflicting cross-version suffixes in: org.apache.spark:spark-tags
[error] (ssExtractDependencies) Conflicting cross-version suffixes in: org.apache.spark:spark-tags
```
I have updated pom to use Scala Binary version 2.13 and changed the tag to 1.2.3 and updated the Scala code to handle changes. The Test cases are passing and now this new jar runs  without any conflicts for spark streaming in my codebase
